### PR TITLE
osk: don't redefine bool and use the standard one instead

### DIFF
--- a/Onboard/osk/osk_module.h
+++ b/Onboard/osk/osk_module.h
@@ -27,7 +27,7 @@
 #include <Python.h>
 #include <structmember.h>
 
-typedef enum { false, true } bool;
+#include <stdbool.h>
 
 /**
  * Python2 to Python3 conversion


### PR DESCRIPTION
The definition looks quite compatible to me.

Encountered at https://github.com/NixOS/nixpkgs/pull/417863
(though nixpkgs does not use your fork yet)