### PR TITLE
Allow to specify unpress_delay via settings

### DIFF
--- a/Onboard/Config.py
+++ b/Onboard/Config.py
@@ -175,9 +175,6 @@ class Config(ConfigObject):
     # raised border size of dish keys
     DISH_KEY_BORDER = (2.5, 2.5)
 
-    # minimum time keys are drawn in pressed state
-    UNPRESS_DELAY = 0.15
-
     # Margin to leave around wordlist labels; smaller margins leave
     # more room for prediction choices
     WORDLIST_LABEL_MARGIN = (2, 2)

--- a/Onboard/Config.py
+++ b/Onboard/Config.py
@@ -1609,7 +1609,7 @@ class ConfigKeyboard(ConfigObject):
         self.add_key("inter-key-stroke-delay", 0.0)
         self.add_key("modifier-update-delay", 1.0)
 
-        self.add_key("unpress-delay", 0.06)
+        self.add_key("unpress-delay", 0.15)
 
         self.add_key("key-press-modifiers", {"button3" : "SHIFT"}, 'a{ss}')
 

--- a/Onboard/Config.py
+++ b/Onboard/Config.py
@@ -1612,6 +1612,8 @@ class ConfigKeyboard(ConfigObject):
         self.add_key("inter-key-stroke-delay", 0.0)
         self.add_key("modifier-update-delay", 1.0)
 
+        self.add_key("unpress-delay", 0.06)
+
         self.add_key("key-press-modifiers", {"button3" : "SHIFT"}, 'a{ss}')
 
     def can_upper_case_on_button(self, button):

--- a/Onboard/Keyboard.py
+++ b/Onboard/Keyboard.py
@@ -110,7 +110,7 @@ class UnpressTimers:
         if not timer:
             timer = Timer()
             self._timers[key] = timer
-        timer.start(config.UNPRESS_DELAY, self.on_timer, key)
+        timer.start(config.keyboard.unpress_delay, self.on_timer, key)
 
     def stop(self, key):
         timer = self._timers.get(key)

--- a/Onboard/KeyboardPopups.py
+++ b/Onboard/KeyboardPopups.py
@@ -474,7 +474,7 @@ class LayoutPopup(KeyboardPopupDrawable, LayoutView, TouchInput):
 
         if key and \
            not self._drag_selected:
-            Timer(config.UNPRESS_DELAY, self.close_window)
+            Timer(config.keyboard.unpress_delay, self.close_window)
         else:
             self.close_window()
 

--- a/Onboard/settings.py
+++ b/Onboard/settings.py
@@ -500,6 +500,16 @@ class Settings(DialogBuilder):
                        config.keyboard, "inter_key_stroke_delay",
                        get_inter_key_stroke_delay, set_inter_key_stroke_delay)
 
+        def get_unpress_delay(config_object, key):
+            return getattr(config_object, key)
+
+        def set_unpress_delay(config_object, key, value):
+            setattr(config_object, key, value)
+
+        self.bind_spin("unpress_delay_spinbutton",
+                       config.keyboard, "unpress_delay",
+                       get_unpress_delay, set_unpress_delay)
+
         # Auto-show
         self._page_auto_show = PageAutoShow(self, builder)
 

--- a/data/org.onboard.gschema.xml
+++ b/data/org.onboard.gschema.xml
@@ -315,6 +315,11 @@ delayed-stroke: generate key-press and key-release on button-release, there is n
             <summary>Delay between key-strokes</summary>
             <description>Delay in seconds between generated key-strokes when inserting word suggestions or snippets. Mainly meant to work around key-stroke losses in Firefox and other Gtk-2 applications. Has no effect on Gtk-3 applications.</description>
         </key>
+        <key name="unpress-delay" type="d">
+            <default>0.06</default>
+            <summary>Unpress delay</summary>
+            <description>Affects how long a key stays highlighed after pressing. High values may feel "laggy". The default value in the older versions was 0.15.</description>
+        </key>
         <key name="modifier-update-delay" type="d">
             <default>1.0</default>
             <summary>Delay until external modifier changes become visible</summary>

--- a/settings.ui
+++ b/settings.ui
@@ -87,6 +87,12 @@
     <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">1</property>
   </object>
+  <object class="GtkAdjustment" id="_unpress_delay_adjustment">
+    <property name="lower">0.0</property>
+    <property name="upper">0.25</property>
+    <property name="step_increment">0.01</property>
+    <property name="page_increment">0.05</property>
+  </object>
   <object class="GtkListStore" id="_input_event_source_liststore">
     <columns>
       <!-- column-name id -->
@@ -2880,6 +2886,89 @@ Requires restart.</property>
                                         <property name="position">2</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkFrame" id="animation_frame">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0</property>
+                                        <property name="shadow_type">none</property>
+                                        <child>
+                                          <object class="GtkBox" id="animation_box">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_top">2</property>
+                                            <property name="margin_left">12</property>
+                                            <property name="orientation">vertical</property>
+                                            <property name="spacing">2</property>
+                                            <child>
+                                              <object class="GtkBox" id="unpress_delay_box">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="spacing">12</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="unpress_delay_label">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="label" translatable="yes">Key unpress delay:</property>
+                                                    <property name="use_underline">True</property>
+                                                    <property name="mnemonic_widget">unpress_delay_spinbutton</property>
+                                                    <property name="single_line_mode">True</property>
+                                                    <property name="xalign">0</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkSpinButton" id="unpress_delay_spinbutton">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="tooltip_text" translatable="yes">Affects how long a key stays highlighed after pressing. High values may feel "laggy". The default value in the older versions was 0.15.</property>
+                                                    <property name="invisible_char">•</property>
+                                                    <property name="xalign">1</property>
+                                                    <property name="shadow_type">out</property>
+                                                    <property name="input_purpose">number</property>
+                                                    <property name="adjustment">_unpress_delay_adjustment</property>
+                                                    <property name="numeric">True</property>
+                                                    <property name="digits">2</property>
+                                                    <property name="text" translatable="yes">0.06</property>
+                                                    <property name="value">0.06</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">1</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="label83">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Animation</property>
+                                            <property name="use_markup">True</property>
+                                            <attributes>
+                                              <attribute name="weight" value="bold"/>
+                                            </attributes>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
@@ -4462,6 +4551,7 @@ Requires restart.</property>
       <widget name="label36"/>
       <widget name="label57"/>
       <widget name="label50"/>
+      <widget name="unpress_delay_label"/>
     </widgets>
   </object>
   <object class="GtkSizeGroup" id="keyboard_options_sizegroup">

--- a/settings.ui
+++ b/settings.ui
@@ -89,7 +89,7 @@
   </object>
   <object class="GtkAdjustment" id="_unpress_delay_adjustment">
     <property name="lower">0.0</property>
-    <property name="upper">0.25</property>
+    <property name="upper">1.25</property>
     <property name="step_increment">0.01</property>
     <property name="page_increment">0.05</property>
   </object>

--- a/settings.ui
+++ b/settings.ui
@@ -2925,7 +2925,7 @@ Requires restart.</property>
                                                   <object class="GtkSpinButton" id="unpress_delay_spinbutton">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
-                                                    <property name="tooltip_text" translatable="yes">Affects how long a key stays highlighed after pressing. High values may feel "laggy". The default value in the older versions was 0.15.</property>
+                                                    <property name="tooltip_text" translatable="yes">Affects how long a key stays highlighed after pressing, also affects the key popups (if activated). Default=0.15, high values may feel "laggy".</property>
                                                     <property name="invisible_char">•</property>
                                                     <property name="xalign">1</property>
                                                     <property name="shadow_type">out</property>
@@ -2933,8 +2933,8 @@ Requires restart.</property>
                                                     <property name="adjustment">_unpress_delay_adjustment</property>
                                                     <property name="numeric">True</property>
                                                     <property name="digits">2</property>
-                                                    <property name="text" translatable="yes">0.06</property>
-                                                    <property name="value">0.06</property>
+                                                    <property name="text" translatable="yes">0.15</property>
+                                                    <property name="value">0.15</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>


### PR DESCRIPTION
Added one of the improvements discussed in #12 

There is now a new setting allowing to change the unpress delay, and the default value is decreased from 0.15 to 0.06, making the typing feel faster and show double key presses as two separate flashes instead of a single long one.

<img width="761" height="695" alt="image" src="https://github.com/user-attachments/assets/a3a2bb50-c63f-4da9-ba52-cb526a550d77" />
