### PR TITLE
Workaround for working on Wayland out-of-the-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Onboard is an onscreen keyboard useful for everybody that cannot use a
 hardware keyboard; for example Tablet-PC users or mobility impaired users.
 It has been designed with simplicity in mind and can be used right away
 without the need of any configuration, as it can read the keyboard layout
-from the X server. Onboard is currently not working with wayland - a correct
-X11/Xorg setup is required.
+from the X server. Onboard can run in Wayland sessions via the XWayland compatibility layer.
 
 ## Building from Source
 Find below short instructions on how to build Onboard straight from this

--- a/onboard
+++ b/onboard
@@ -32,6 +32,28 @@ import os
 # exceptions.
 from Onboard.Exceptions import chain_handler
 sys.excepthook = chain_handler
-    
+
+# If we're running under Wayland, force the GDK backend to X11 so Onboard runs through XWayland.
+# Also set some keyboard settings to ensure Onboard works correctly.
+def _ensure_work_on_wayland():
+	try:
+		if os.environ.get('XDG_SESSION_TYPE', '').lower() == 'wayland' or ('WAYLAND_DISPLAY' in os.environ):
+			os.environ.setdefault('GDK_BACKEND', 'x11')
+
+			import gi
+			gi.require_version('Gio', '2.0')
+			gi.require_version('GLib', '2.0')
+			from gi.repository import Gio, GLib
+
+			kb = Gio.Settings.new('org.onboard.keyboard')
+			kb.set_value('input-event-source', GLib.Variant('i', 0))
+			kb.set_value('key-synth', GLib.Variant('i', 2))
+
+	except Exception:
+		pass
+
+
+_ensure_work_on_wayland()
+
 from Onboard.OnboardGtk import OnboardGtk as Onboard
 ob = Onboard()


### PR DESCRIPTION
Link: https://github.com/onboard-osk/onboard/issues/3.

This is a very primitive workaround based on: https://discuss.kde.org/t/plasma-6-and-wayland-no-on-screen-keyboard-working/17799/47. I think that this is better than nothing, and should be present as a workaround fix to solve the problem in most Wayland-based environments. It would be nice if it also prevented the ability to change workaround settings while workaround is in use, but I'm not good enough at Python to do this well.

Unfortunately, there are no generic way to make onboard works natively on top of most Wayland compositors because there are no ability to set some window properties like "_NET_WM_STATE_ABOVE, _NET_WM_STATE_STAYS_ON_TOP" and "WM_HINTS(WM_HINTS): Client accepts input or input focus: False for ordinary client".

Note: it's possible to reproduce the behavior on Wayland of being above other windows and ignoring activation (focus) using the wlr_layer_shell protocol, but the window will loose its xdg_shell traits such as client decorations, positioning and resizing.