### PR TITLE
Safe DPI calculation

### DIFF
--- a/Onboard/WindowUtils.py
+++ b/Onboard/WindowUtils.py
@@ -1055,6 +1055,11 @@ def get_monitor_dimensions(window):
             size = 1280, 800
             size_mm = 150, 94
 
+        dpi_x = size[0] * 25.4 / size_mm[0]
+        dpi_y = size[1] * 25.4 / size_mm[1]
+        if dpi_x < 50 or dpi_x > 200 or dpi_y < 50 or dpi_y > 200:
+            size_mm = 0, 0
+
         return size, size_mm
     else:
         return (0, 0), (0, 0)

--- a/Onboard/WindowUtils.py
+++ b/Onboard/WindowUtils.py
@@ -1057,7 +1057,7 @@ def get_monitor_dimensions(window):
 
         dpi_x = size[0] * 25.4 / size_mm[0]
         dpi_y = size[1] * 25.4 / size_mm[1]
-        if dpi_x < 50 or dpi_x > 200 or dpi_y < 50 or dpi_y > 200:
+        if dpi_x < 50 or dpi_x > 350 or dpi_y < 50 or dpi_y > 350:
             size_mm = 0, 0
 
         return size, size_mm

--- a/Onboard/WindowUtils.py
+++ b/Onboard/WindowUtils.py
@@ -1055,8 +1055,9 @@ def get_monitor_dimensions(window):
             size = 1280, 800
             size_mm = 150, 94
 
-        dpi_x = size[0] * 25.4 / size_mm[0]
-        dpi_y = size[1] * 25.4 / size_mm[1]
+        dpi_x = size[0] * 25.4 / size_mm[0] if size_mm[0] != 0 else 0
+        dpi_y = size[1] * 25.4 / size_mm[1] if size_mm[1] != 0 else 0
+
         if dpi_x < 50 or dpi_x > 350 or dpi_y < 50 or dpi_y > 350:
             size_mm = 0, 0
 


### PR DESCRIPTION
Some monitors I have experience with have wrong EDID reading for the physical size. This causes scaling issues. This PR invalides the physical size if DPI is below 50 or above 200

From xrandr:
```
HDMI-1 connected 1366x768+0+0 (normal left inverted right x axis y axis) 34mm x 20mm
   1366x768      60.21*+
```