### PR TITLE
Disable docking when x/y coordinates are specified via command line

### DIFF
--- a/Onboard/Config.py
+++ b/Onboard/Config.py
@@ -1129,6 +1129,10 @@ class Config(ConfigObject):
                self.quirks.can_set_override_redirect(self)
 
     def is_docking_enabled(self):
+        # Disable docking when x/y coordinates were explicitly provided
+        # via command line to respect user's positioning choice
+        if self.options and (self.options.x is not None or self.options.y is not None):
+            return False
         return self.window.docking_enabled
 
     def is_dock_expanded(self, orientation_co):


### PR DESCRIPTION
When the user explicitly provides window positioning via -x and/or -y command line arguments, disable docking to respect the user's choice.

Co-authored-by: Z.AI GLM