### PR TITLE
Honor punctuation_assistance option when handling separators before punctuation

### DIFF
--- a/Onboard/WordSuggestions.py
+++ b/Onboard/WordSuggestions.py
@@ -1889,6 +1889,8 @@ class PunctuatorImmediateSeparators(Punctuator):
         """
         caps_mode = False
 
+        if not config.wp.punctuation_assistance:
+            return # do not eat space between "ls ." if option disabled
         # before punctuation remove the separator again
         if self._added_separator_span and \
            key.is_text_changing():


### PR DESCRIPTION
### **Summary**

This patch fixes an issue where Onboard removes the separator (typically a space) before punctuation **even when the user has disabled punctuation assistance**

This caused unintended deletion of spaces inserted by word completion, especially in terminal workflows.

**Example of current (incorrect) behavior:**

1. Type: `l`  
2. Choose suggestion: `ls␣`  
3. Type: `.`  
4. Result: `ls.` ← *unwanted — auto‑deleted space*

**Expected behavior when punctuation assistance is disabled:**

```
ls .
```

This patch restores the expected behavior.

---

### **Root Cause**

The separator deletion happens inside `WordSuggestions.py` in the block:

```
# before punctuation remove the separator again
```

This cleanup runs **unconditionally**, regardless of the user's `punctuation_assistance` setting, which contradicts the configuration semantics.

---

### **Fix**

The patch adds a simple configuration guard.

This ensures that spacing cleanup logic is *completely skipped* when the user disables punctuation assistance.

---

### **Impact**

- ✅ Preserves separators before punctuation in terminal and coding contexts  
- ✅ Honors user preference for disabling punctuation assistance  
- ✅ Retains existing behavior when punctuation assistance is enabled  
- ✅ Very small, low‑risk, localized change  
- ✅ Confirmed working in testing

---

### **Additional Notes**

This makes `punctuation_assistance` behave consistently:

- When **enabled** → smart punctuation cleanup, spacing adjustment, etc.  
- When **disabled** → Onboard does *not* remove separators or alter spacing

This change improves predictability for users who rely on precise text input — especially in shells.

This also adresses issue #36.