### PR TITLE
Add missing Ubuntu dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ new distributions are always welcome too.
         sudo apt install dh-python python3-distutils-extra devscripts pkg-config
         sudo apt install libgtk-3-dev libxtst-dev libxkbfile-dev libdconf-dev libcanberra-dev
         sudo apt install libhunspell-dev libudev-dev
+        sudo apt install python3-gi-cairo
         
         Next step is "Build and Install from Source"
 


### PR DESCRIPTION
I was recently building Onboard on fresh Ubuntus 26.04 and 24.04, and was getting a confusing error about `'cairo.Context'` on launch.
The fix was simply to install this dependency

```
sudo apt install python3-gi-cairo
```

 so it probably should be added into the readme. 