### PR TITLE
fix: prevent crash on shutdown caused by BadWindow X error

### DIFF
--- a/Onboard/OnboardGtk.py
+++ b/Onboard/OnboardGtk.py
@@ -855,6 +855,11 @@ class OnboardGtk(object):
         self.status_icon = None
 
         self._window.cleanup()
+
+        # Ignore all X errors during window destruction and GTK shutdown.
+        # GDK error traps are unreliable here; use a bare Xlib handler.
+        self._osk_util.set_x_error_ignore()
+        
         self._window.destroy()
         self._window = None
         Gtk.main_quit()

--- a/Onboard/osk/osk_util.c
+++ b/Onboard/osk/osk_util.c
@@ -715,9 +715,29 @@ osk_util_idle_call (PyObject* callback, PyObject* arglist)
     g_idle_add ((GSourceFunc) idle_call, data);
 }
 
+static int
+osk_x_error_ignore (Display *dpy, XErrorEvent *err)
+{
+    (void) dpy;
+    (void) err;
+    return 0;
+}
+
+static PyObject *
+osk_util_set_x_error_ignore (PyObject *self, PyObject *args)
+{
+    (void) self;
+    (void) args;
+    XSetErrorHandler (osk_x_error_ignore);
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef osk_util_methods[] = {
     { "set_x_property",
         osk_util_set_x_property,
+        METH_VARARGS, NULL },
+    { "set_x_error_ignore",
+        osk_util_set_x_error_ignore,
         METH_VARARGS, NULL },
     { "set_unix_signal_handler",
         osk_util_set_unix_signal_handler,


### PR DESCRIPTION
When onboard receives SIGTERM (e.g. after user login completes and lightdm closes the greeter), GTK destroys the keyboard window and emits the unrealize signal. At this point the underlying X window has already been destroyed, but pending X requests (XISelectEvents,XSync, XPending) against the now-invalid window ID trigger BadWindow errors. 
GDK error traps fail to intercept these errors in this context, causing GLib's fatal error handler to call raise(SIGTRAP), which crashes the process and produces a core dump.

Fix by calling XSetErrorHandler() with a silent ignore handler just before window destruction begins. This covers the entire shutdown sequence including the gdk_flush() call inside gtk_main() on exit.
The original error handler is restored after Gtk.main_quit() returns.

This was observed on Deepin (aarch64 and x86_64 and more) with

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com