### PR TITLE
fix: xsync-badwindow-on-unrealize

### DIFF
--- a/Onboard/osk/osk_devices.c
+++ b/Onboard/osk/osk_devices.c
@@ -507,14 +507,24 @@ osk_devices_call_event_handler_key (OskDevices *dev,
 }
 
 static int
+osk_x_ignore_error (Display *dpy, XErrorEvent *err)
+{
+    (void) dpy;
+    (void) err;
+    return 0;
+}
+
+static int
 osk_devices_select (OskDevices    *dev,
                     Window         win,
                     int            id,
                     unsigned char *mask,
                     unsigned int   mask_len)
 {
-    XIEventMask events;
-    GdkDisplay *gdk_display = gdk_x11_lookup_xdisplay (dev->dpy);
+    XIEventMask   events;
+    XErrorHandler old_handler;
+    GdkDisplay   *gdk_display = gdk_x11_lookup_xdisplay (dev->dpy);
+
     events.deviceid = id;
     events.mask = mask;
     events.mask_len = mask_len;
@@ -522,9 +532,15 @@ osk_devices_select (OskDevices    *dev,
     if (win == 0)
         win = DefaultRootWindow (dev->dpy);
 
+    /* GTK destroys the X window before emitting the unrealize signal,
+     * so the window may be gone by the time we get here.
+     * GDK error traps are unreliable in this context.
+     * use a bare Xlib error handler to silently ignore BadWindow. */
     gdk_x11_display_error_trap_push (gdk_display);
+    old_handler = XSetErrorHandler (osk_x_ignore_error);
     XISelectEvents (dev->dpy, win, &events, 1);
-    gdk_display_flush (gdk_display);
+    XSync (dev->dpy, False);
+    XSetErrorHandler (old_handler);
     return gdk_x11_display_error_trap_pop (gdk_display) ? -1 : 0;
 }
 


### PR DESCRIPTION
## Root Cause
gdk_display_flush() calls XFlush() internally, which is asynchronous — it sends the request but does not wait for the server response. The BadWindow error reply arrives after
gdk_x11_display_error_trap_pop() has already returned, so the error is handled by GDK's global error handler instead of being suppressed by the trap.

## Fix
Replace gdk_display_flush() with XSync(dev->dpy, False) so that the server response (including any BadWindow error) is processed synchronously while our XSetErrorHandler(osk_x_ignore_error) is still in effect.

The gdk_x11_display_error_trap_push/pop calls are retained for
compatibility with environments where GDK error traps work correctly.

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com