### PR TITLE
refactor: improve-robustness

### DIFF
--- a/Onboard/OnboardGtk.py
+++ b/Onboard/OnboardGtk.py
@@ -673,8 +673,10 @@ class OnboardGtk(object):
         GLib.idle_add(self._update_docking_delayed)
 
     def _update_docking_delayed(self):
-        self._window.on_docking_notify()
-        self.keyboard.invalidate_ui()  # show/hide the move button
+        if self._window:
+            self._window.on_docking_notify()
+        if self.keyboard:
+            self.keyboard.invalidate_ui()  # show/hide the move button
 #        self.keyboard.commit_ui_updates() # redundant
 
     def on_gdk_setting_changed(self, name):
@@ -801,7 +803,8 @@ class OnboardGtk(object):
                        if color_scheme_filename else None
         layout = LayoutLoaderSVG().load(vk, layout_filename, color_scheme)
 
-        self.keyboard.set_layout(layout, color_scheme, vk)
+        if layout:
+            self.keyboard.set_layout(layout, color_scheme, vk)
 
         if self._window and self._window.icp:
             self._window.icp.queue_draw()


### PR DESCRIPTION
Add existence checks before calling methods on _window, keyboard, and layout to prevent AttributeError crashes when objects are not yet initialized or have already been destroyed.

Changes:
_update_docking_delayed: Guard _window.on_docking_notify() and keyboard.invalidate_ui() with if self._window and if self.keyboard. This method is scheduled via GLib.idle_add and may fire after these objects have been torn down.

load_layout: Guard keyboard.set_layout() with if layout. LayoutLoaderSVG().load() can return None on failure; passing None into set_layout would cause a downstream crash.

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com