### PR TITLE
fix: wayland-label-strncpy-oob

### DIFF
--- a/Onboard/osk/osk_virtkey_wayland.c
+++ b/Onboard/osk/osk_virtkey_wayland.c
@@ -323,8 +323,8 @@ virtkey_wayland_get_label_from_keycode(VirtkeyBase* base,
 {
     int keysym = virtkey_wayland_get_keysym_from_keycode(
                         base, keycode, modmask, group);
-    strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size);
-    label[max_label_size] = '\0';
+    strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size - 1);
+    label[max_label_size - 1] = '\0';
 
     //g_debug("virtkey_wayland_get_label_from_keycode: keycode: %d, modmask %d, group %d, label '%s'\n",
     //        keycode, modmask, group, label);


### PR DESCRIPTION
Fix out-of-bounds write in virtkey_wayland_get_label_from_keycode
In virtkey_wayland_get_label_from_keycode, the buffer label of size max_label_size was written one byte past its end:

    strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size);
    label[max_label_size] = '\0';  // out-of-bounds write

label[max_label_size] is one past the last valid index, causing
undefined behaviour (stack or heap corruption depending on the
caller's allocation).

Fix by using max_label_size - 1 as the copy limit so the null
terminator lands within bounds.

Signed-off-by: dongshengyuan <dongshengyuan@uniontech.com>