### PR TITLE
fix: wayland-xkb-update-mask-group-arg

### DIFF
--- a/Onboard/osk/osk_virtkey_wayland.c
+++ b/Onboard/osk/osk_virtkey_wayland.c
@@ -576,7 +576,7 @@ keyboard_handle_modifiers(void *data, struct wl_keyboard *keyboard,
     g_debug("keyboard_handle_modifiers: depressed %d, latched %d, locked %d, group %d\n",
             mods_depressed, mods_latched, mods_locked, group);
 
-    xkb_state_update_mask (this->xkb_state, mods_depressed, mods_latched, mods_locked, group, 0, 0);
+    xkb_state_update_mask (this->xkb_state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
     {
         VirtkeyBase* base = data;
         struct xkb_keymap* xkb_keymap = get_gdk_xkb_keymap(base);


### PR DESCRIPTION
fix: pass wl_keyboard group to locked_layout in xkb_state_update_mask

The Wayland wl_keyboard.modifiers group field is the locked layout index, but it was incorrectly passed as depressed_layout (4th layout argument) instead of locked_layout (6th). 

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com