### PR TITLE
fix: wayland-strdup-null-group-name

### DIFF
--- a/Onboard/osk/osk_virtkey_wayland.c
+++ b/Onboard/osk/osk_virtkey_wayland.c
@@ -134,11 +134,11 @@ virtkey_wayland_get_current_group_name (VirtkeyBase* base)
 {
     struct xkb_keymap* xkb_keymap = get_xkb_keymap(base);
     int group = virtkey_wayland_get_current_group(base);
-    const char* name = "";
+    const char* name = NULL;
     if (xkb_keymap)
         name = xkb_keymap_layout_get_name(xkb_keymap, group);
     //g_debug("virtkey_wayland_get_current_group_name %d '%s'\n", group, name);
-    return strdup(name);
+    return strdup(name ? name : "");
 }
 
 static bool


### PR DESCRIPTION
fix: guard against NULL return from xkb_keymap_layout_get_name

xkb_keymap_layout_get_name is documented to return NULL in two cases:
  - If the index is invalid
  - If the layout does not have a name

The previous code assigned the return value directly to `name` and passed it to strdup() without a NULL check. strdup(NULL) is undefined behavior and segfaults on glibc.

The initial value `name = ""` appeared to be a safety net, but was silently overwritten by the assignment inside the if-block, leaving no protection against a NULL return.

Fix by checking at the point of use:

    return strdup(name ? name : "");

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com