### PR TITLE
Fix handling left click and switch to maintained Ayatana Appindicator

### DIFF
--- a/Onboard/Indicator.py
+++ b/Onboard/Indicator.py
@@ -294,7 +294,7 @@ class BackendAppIndicator(BackendBase):
         BackendBase.__init__(self, menu)
 
         try:
-            from gi.repository import AppIndicator3 as AppIndicator
+            from gi.repository import AyatanaAppIndicator3 as AppIndicator
         except ImportError as ex:
             raise RuntimeError(ex)
 
@@ -350,7 +350,7 @@ class BackendAppIndicator(BackendBase):
 
     def _set_indicator_active(self, active):
         try:
-            from gi.repository import AppIndicator3 as AppIndicator
+            from gi.repository import AyatanaAppIndicator3 as AppIndicator
         except ImportError:
             pass
         else:

--- a/Onboard/Indicator.py
+++ b/Onboard/Indicator.py
@@ -286,8 +286,11 @@ class BackendAppIndicator(BackendBase):
 
         try:
             from gi.repository import AyatanaAppIndicator3 as AppIndicator
-        except ImportError as ex:
-            raise RuntimeError(ex)
+        except ImportError:
+            try:
+                from gi.repository import AppIndicator3 as AppIndicator
+            except ImportError as ex:
+                raise RuntimeError(ex)
 
         self._indicator = AppIndicator.Indicator.new(
             self.id,
@@ -303,9 +306,14 @@ class BackendAppIndicator(BackendBase):
         # Connect to the "activate" signal for left-click handling.
         # The library handles the D-Bus Activate method and emits this
         # signal when the tray icon is left-clicked (e.g. in KDE Plasma).
-        self._indicator.connect("activate",
-                                lambda indicator, x, y:
-                                menu.on_show_keyboard_toggle())
+        # Only present with AyatanaIndicators/libayatana-appindicator#4.
+        if GObject.signal_lookup("activate", type(self._indicator)):
+            self._indicator.connect("activate",
+                                    lambda *args:
+                                    menu.on_show_keyboard_toggle())
+        else:
+            _logger.warning("AppIndicator lacks 'activate' signal, "
+                            "left-click toggle unavailable")
 
     def cleanup(self):
         pass
@@ -315,7 +323,10 @@ class BackendAppIndicator(BackendBase):
 
     def _set_indicator_active(self, active):
         try:
-            from gi.repository import AyatanaAppIndicator3 as AppIndicator
+            try:
+                from gi.repository import AyatanaAppIndicator3 as AppIndicator
+            except ImportError:
+                from gi.repository import AppIndicator3 as AppIndicator
         except ImportError:
             pass
         else:

--- a/Onboard/Indicator.py
+++ b/Onboard/Indicator.py
@@ -23,11 +23,6 @@ from __future__ import division, print_function, unicode_literals
 
 import subprocess
 
-try:
-    import dbus
-except ImportError:
-    pass
-
 from Onboard.Version import require_gi_versions
 require_gi_versions()
 from gi.repository import GObject, Gtk
@@ -286,10 +281,6 @@ class BackendAppIndicator(BackendBase):
 
     _indicator = None
 
-    STATUSNOTIFIER_OBJECT = "/org/ayatana/NotificationItem/Onboard"
-    STATUSNOTIFIER_IFACE = "org.kde.StatusNotifierItem"
-    ACTIVATE_METHOD = "Activate"
-
     def __init__(self, menu):
         BackendBase.__init__(self, menu)
 
@@ -309,41 +300,15 @@ class BackendAppIndicator(BackendBase):
         self._indicator.set_secondary_activate_target(
             menu._menu.get_children()[0])
 
-        if "dbus" in globals():
-            # Watch left-click Activate() calls on desktops that send them
-            # (KDE Plasma). There is still "No such method 'Activate'" in
-            # AppIndicator.
-            try:
-                self._bus = dbus.SessionBus()
-            except dbus.exceptions.DBusException as ex:
-                _logger.warning("D-Bus session bus unavailable, "
-                                "no left-click Activate() for AppIndicator: " +
-                                unicode_str(ex))
-            else:
-                try:
-                    self._bus.add_match_string(
-                        "type='method_call',"
-                        "eavesdrop=true,"
-                        "path='{}',"
-                        "interface='{}',"
-                        "member='{}'"
-                        .format(self.STATUSNOTIFIER_OBJECT,
-                                self.STATUSNOTIFIER_IFACE,
-                                self.ACTIVATE_METHOD))
-                    self._bus.add_message_filter(self._on_activate_method)
-                except dbus.exceptions.DBusException as ex:
-                    _logger.warning("Failed to setup D-Bus match rule, "
-                                    "no left-click Activate() for AppIndicator: " +
-                                    unicode_str(ex))
+        # Connect to the "activate" signal for left-click handling.
+        # The library handles the D-Bus Activate method and emits this
+        # signal when the tray icon is left-clicked (e.g. in KDE Plasma).
+        self._indicator.connect("activate",
+                                lambda indicator, x, y:
+                                menu.on_show_keyboard_toggle())
 
     def cleanup(self):
         pass
-
-    def _on_activate_method(self, bus, message):
-        if message.get_path() == self.STATUSNOTIFIER_OBJECT and \
-           message.get_member() == self.ACTIVATE_METHOD:
-            self._menu.on_show_keyboard_toggle()
-        return dbus.connection.HANDLER_RESULT_NOT_YET_HANDLED
 
     def set_visible(self, visible):
         self._set_indicator_active(visible)

--- a/Onboard/Version.py
+++ b/Onboard/Version.py
@@ -33,9 +33,9 @@ def require_gi_versions():
     except ValueError:
         pass
 
-    # AppIndicator3 is not required
+    # AyatanaAppIndicator3 is not required
     try:
-        gi.require_version('AppIndicator3', '0.1')
+        gi.require_version('AyatanaAppIndicator3', '0.1')
     except ValueError:
         pass
 

--- a/Onboard/Version.py
+++ b/Onboard/Version.py
@@ -39,3 +39,8 @@ def require_gi_versions():
     except ValueError:
         pass
 
+    try:
+        gi.require_version('AppIndicator3', '0.1')
+    except ValueError:
+        pass
+


### PR DESCRIPTION
Left click both showed the context menu and emited show/hide of the keyboard.

Now it only shows/hides the keyboard, right click shows the context menu.

Works only with this patch: https://github.com/AyatanaIndicators/libayatana-appindicator/pull/4