### PR TITLE
harden: use max_label_size-1 in get_label_from_keycode strncpy calls

### DIFF
--- a/Onboard/osk/osk_virtkey_wayland.c
+++ b/Onboard/osk/osk_virtkey_wayland.c
@@ -323,8 +323,8 @@ virtkey_wayland_get_label_from_keycode(VirtkeyBase* base,
 {
     int keysym = virtkey_wayland_get_keysym_from_keycode(
                         base, keycode, modmask, group);
-    strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size);
-    label[max_label_size] = '\0';
+    strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size - 1);
+    label[max_label_size - 1] = '\0';
 
     //g_debug("virtkey_wayland_get_label_from_keycode: keycode: %d, modmask %d, group %d, label '%s'\n",
     //        keycode, modmask, group, label);

--- a/Onboard/osk/osk_virtkey_x.c
+++ b/Onboard/osk/osk_virtkey_x.c
@@ -402,8 +402,8 @@ virtkey_x_get_label_from_keycode(VirtkeyBase* base,
 
     if (keysym)
     {
-        strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size);
-        label[max_label_size] = '\0';
+        strncpy(label, virtkey_get_label_from_keysym(keysym), max_label_size - 1);
+        label[max_label_size - 1] = '\0';
     }
 }
 


### PR DESCRIPTION
This change is applied to both osk_virtkey_wayland.c and osk_virtkey_x.c, ensuring the two backends share the same convention.

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com