### PR TITLE
fix: uinput-fd-leak

### DIFF
--- a/Onboard/osk/osk_uinput.c
+++ b/Onboard/osk/osk_uinput.c
@@ -93,6 +93,7 @@ uinput_open (UInput* uinput, const char* device_name)
     if(ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0)
     {
         PyErr_SetString (OSK_EXCEPTION, "error in ioctl UI_SET_EVBIT");
+        close(fd);
         return -2;
     }
 
@@ -130,6 +131,7 @@ uinput_open (UInput* uinput, const char* device_name)
             if (ioctl(fd, UI_SET_KEYBIT, i) < 0)
             {
                 PyErr_SetString (OSK_EXCEPTION, "error in ioctl UI_SET_KEYBIT");
+                close(fd);
                 return -3;
             }
         }
@@ -146,6 +148,7 @@ uinput_open (UInput* uinput, const char* device_name)
     if(write(fd, uidev, sizeof(*uidev)) < 0)
     {
         PyErr_SetString (OSK_EXCEPTION, "error writing uinput device struct");
+        close(fd);
         return -4;
     }
 
@@ -153,6 +156,7 @@ uinput_open (UInput* uinput, const char* device_name)
     {
         PyErr_SetString (OSK_EXCEPTION, 
                          "error creating uinput device: ioctl UI_DEV_CREATE");
+        close(fd);
         return -5;
     }
 


### PR DESCRIPTION
After open("/dev/uinput") succeeds, four subsequent error paths
return without closing the file descriptor:

- ioctl UI_SET_EVBIT failure  (returned -2)
- ioctl UI_SET_KEYBIT failure (returned -3)
- write uinput_user_dev failure (returned -4)
- ioctl UI_DEV_CREATE failure  (returned -5)

Each leaked fd stays open until process exit.
Add close(fd) before each early return to fix all four paths.

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com