### PR TITLE
fix: canvas-to-root-window-point-typo

### DIFF
--- a/Onboard/WindowUtils.py
+++ b/Onboard/WindowUtils.py
@@ -1040,7 +1040,7 @@ def canvas_to_root_window_point(window, point):
     if gdk_win:
         point = gdk_win.get_root_coords(*point)
     else:
-        point(0, 0)
+        point = (0, 0)
     return point
 
 def get_monitor_dimensions(window):


### PR DESCRIPTION
fix: correct point assignment typo in canvas_to_root_window_point

In the else branch of canvas_to_root_window_point(), the fallback
was written as:

    point(0, 0)

instead of:

    point = (0, 0)

Signed-off-by: dongshengyuan dongshengyuan@uniontech.com
