### PR TITLE
fix: SCBackend_cmd.stop() calls super().__init__ instead of super().stop()

### DIFF
--- a/Onboard/SpellChecker.py
+++ b/Onboard/SpellChecker.py
@@ -526,7 +526,7 @@ class SCBackend_cmd(SCBackend):
         self._p = None
 
     def stop(self):
-        super(SCBackend_cmd, self).__init__(dict_ids)
+        super(SCBackend_cmd, self).stop()
         if self.is_running():
             self._p.terminate()
             self._p.wait()


### PR DESCRIPTION
fix: SCBackend_cmd.stop() calls super().__init__ instead of super().stop()
The stop() method incorrectly called the parent's __init__ with an
undefined variable dict_ids, which would raise NameError at runtime.
Replace with the correct super().stop() call.

Signed-off-by: dongshengyuan <dongshengyuan@uniontech.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>