### PR TITLE
fix: add NULL check for malloc in virtkey_x_new

### DIFF
--- a/Onboard/osk/osk_virtkey_x.c
+++ b/Onboard/osk/osk_virtkey_x.c
@@ -647,6 +647,8 @@ VirtkeyBase*
 virtkey_x_new(void)
 {
    VirtkeyBase* this = (VirtkeyBase*) malloc(sizeof(VirtkeyX));
+   if (!this)
+       return NULL;
    this->init = virtkey_x_init;
    this->destruct = virtkey_x_destruct;
    this->reload = virtkey_x_reload;


### PR DESCRIPTION
fix: add NULL check for malloc in virtkey_x_new
Check malloc return value before dereferencing in virtkey_x_new();
return NULL on allocation failure.

Signed-off-by: dongshengyuan <dongshengyuan@uniontech.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>