### PR TITLE
at-spi: Fix inserting multi-byte unicode characters

### DIFF
--- a/Onboard/AtspiStateTracker.py
+++ b/Onboard/AtspiStateTracker.py
@@ -335,16 +335,12 @@ class CachedAccessible:
                          unicode_str(ex))
 
     def insert_text(self, position, text):
-        # AT-SPI's atspi_editable_text_insert_text() takes the number
-        # of *characters* to insert, not bytes. Passing -1 works for
-        # the GTK bridge (it computes strlen on its side) but Qt's
-        # accessibility bridge truncates to length=0 on -1 and the
-        # insert silently no-ops. Pass the actual character count.
         try:
-            ok = self._accessible.insert_text(position, text, len(text))
+            length = len(bytes(text, 'utf-8'))
+            ok = self._accessible.insert_text(position, text, length)
             _logger.atspi(
                 "CachedAccessible.insert_text(pos={}, text={!r}, "
-                "len={}) -> {}".format(position, text, len(text), ok))
+                "len={}) -> {}".format(position, text, length, ok))
             return ok
         except Exception as ex:  # Private exception gi._glib.GErro
             _logger.warning("CachedAccessible.insert_text() failed: " +


### PR DESCRIPTION
`EditableText.insert_text` does take the number of bytes and not the number of characters to insert as the comment alleges. Documented here: https://gnome.pages.gitlab.gnome.org/at-spi2-core/libatspi/method.EditableText.insert_text.html

Python AtSpi documentation: https://lazka.github.io/pgi-docs/index.html#Atspi-2.0/classes/EditableText.html#Atspi.EditableText.insert_text

This leads to issues inserting letters with accents or emojis into GTK3 applications. The length sent is 1 but should be 2 for accented letters and 4 for some emojis so nothing ends up being inserted.

I've tested this change with caja (gtk3), nautilus (gtk4) and dolphin (QT6) and the characters are being inserted properly.