### PR TITLE
OnboardIndicator: Fix instantiation of OnboardProxy

### DIFF
--- a/gnome/current/Onboard_Indicator@onboard.org/extension.js
+++ b/gnome/current/Onboard_Indicator@onboard.org/extension.js
@@ -93,7 +93,7 @@ class Onboard {
         try {
             // Try to connect asynchronously to DBus
             this.proxy = await new Promise((resolve, reject) => {
-                this.OnboardProxy(
+                new this.OnboardProxy(
                     Gio.DBus.session,
                     'org.onboard.Onboard',
                     '/org/onboard/Onboard/Keyboard',


### PR DESCRIPTION
As per GJS change in https://gitlab.gnome.org/GNOME/gjs/-/commit/77d8c324 it's required to use the new operator to instantiate the wrapper objects